### PR TITLE
Pin package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "license": "MIT",
   "engines" : { "node" : ">=4.1.0 <5.5.0" },
   "dependencies": {
-    "dotenv": "^1.2.0",
-    "express": "^4.13.3",
-    "twilio": "^3.0.0-edge"
+    "dotenv": "2.0.0",
+    "express": "4.14.0",
+    "twilio": "2.11.0"
   }
 }


### PR DESCRIPTION
This fixes access to AccessToken.ConversationsGrant and keeps the quickstart versions stable.  Without this, a fresh npm install pulls in 3.0.0-rc.13  which results in the following error

```
video-quickstart-node-master/index.js:12
var AccessToken = require('twilio').AccessToken;
                                       ^

TypeError: Cannot read property 'AccessToken' of undefined
    at Object.<anonymous> (/video-quickstart-node-master/index.js:12:40)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.runMain (module.js:590:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
```