### PR TITLE
Connect and Media API changes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
   </div>
 
   <script src="//media.twiliocdn.com/sdk/js/common/v0.1/twilio-common.min.js"></script>
-  <script src="//media.twiliocdn.com/sdk/js/video/releases/1.0.0-beta2/twilio-video.js"></script>
+  <script src="//media.twiliocdn.com/sdk/js/video/releases/1.0.0-beta5/twilio-video.js"></script>
   <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
   <script src="quickstart.js"></script>
 </body>

--- a/public/quickstart.js
+++ b/public/quickstart.js
@@ -3,30 +3,28 @@ var previewTracks;
 var identity;
 var roomName;
 
-function attachMedia(tracks, container) {
-  tracks.map(function(track) {
-    return track.attach();
-  }).forEach(function(mediaElement) {
-    container.appendChild(mediaElement);
+function attachTracks(tracks, container) {
+  tracks.forEach(function(track) {
+    container.appendChild(track.attach());
   });
 }
 
-function attachParticipantMedia(participant, container) {
-  attachMedia(Array.from(participant.tracks.values()), container);
+function attachParticipantTracks(participant, container) {
+  var tracks = Array.from(participant.tracks.values());
+  attachTracks(tracks, container);
 }
 
-function detachMedia(tracks) {
-  tracks.map(function(track) {
-    return track.detach();
-  }).forEach(function(mediaElements) {
-    mediaElements.forEach(function(mediaElement) {
-      mediaElement.remove();
+function detachTracks(tracks) {
+  tracks.forEach(function(track) {
+    track.detach().forEach(function(detachedElement) {
+      detachedElement.remove();
     });
   });
 }
 
-function detachParticipantMedia(participant) {
-  detachMedia(Array.from(participant.tracks.values()));
+function detachParticipantTracks(participant) {
+  var tracks = Array.from(participant.tracks.values());
+  detachTracks(tracks);
 }
 
 // Check for WebRTC
@@ -80,13 +78,13 @@ function roomJoined(room) {
   // Draw local video, if not already previewing
   var previewContainer = document.getElementById('local-media');
   if (!previewContainer.querySelector('video')) {
-    attachParticipantMedia(room.localParticipant, previewContainer);
+    attachParticipantTracks(room.localParticipant, previewContainer);
   }
 
   room.participants.forEach(function(participant) {
     log("Already in Room: '" + participant.identity + "'");
     var previewContainer = document.getElementById('remote-media');
-    attachParticipantMedia(participant, previewContainer);
+    attachParticipantTracks(participant, previewContainer);
   });
 
   // When a participant joins, draw their video on screen
@@ -97,26 +95,26 @@ function roomJoined(room) {
   room.on('trackAdded', function(track, participant) {
     log(participant.identity + " added track: " + track.kind);
     var previewContainer = document.getElementById('remote-media');
-    attachMedia([track], previewContainer);
+    attachTracks([track], previewContainer);
   });
 
   room.on('trackRemoved', function(track, participant) {
     log(participant.identity + " removed track: " + track.kind);
-    detachMedia([track]);
+    detachTracks([track]);
   });
 
   // When a participant disconnects, note in log
   room.on('participantDisconnected', function(participant) {
     log("Participant '" + participant.identity + "' left the room");
-    detachParticipantMedia(participant);
+    detachParticipantTracks(participant);
   });
 
   // When we are disconnected, stop capturing local video
   // Also remove media for all remote participants
   room.on('disconnected', function() {
     log('Left');
-    detachParticipantMedia(room.localParticipant);
-    room.participants.forEach(detachParticipantMedia);
+    detachParticipantTracks(room.localParticipant);
+    room.participants.forEach(detachParticipantTracks);
     activeRoom = null;
     document.getElementById('button-join').style.display = 'inline';
     document.getElementById('button-leave').style.display = 'none';
@@ -133,7 +131,7 @@ document.getElementById('button-preview').onclick = function() {
     previewTracks = tracks;
     var previewContainer = document.getElementById('local-media');
     if (!previewContainer.querySelector('video')) {
-      attachMedia(tracks, previewContainer);
+      attachTracks(tracks, previewContainer);
     }
   }, function(error) {
     console.error('Unable to access local media', error);


### PR DESCRIPTION
@kwhinnery @markandrus ,

This PR contains the following changes:
* `Client` class has been removed and replaced with a `connect()` method.
* `getUserMedia()` has been replaced with `createLocalTracks()`.
* `createLocalAudioTrack()` method has been added to create a single audio track.
* `createLocalVideoTrack()` method has been added to create a single video track.
* `Media/LocalMedia` classes have been removed.
* `LocalParticipant` now maintains `tracks`, `audioTracks` and `videoTracks`.
* `LocalParticipant` has new methods `addTrack()` and `removeTrack()`.
* Fixed a bug where if you click on "preview my camera", then join a Room, leave, and join back, the preview wouldn't re-appear.

NOTE: These changes are being tested right now as part of `twilio-video#1.0.0-rc16`, and is scheduled to be pushed out with `twilio-video#1.0.0-beta5`. So you guys can review and suggest changes for now, and merge this PR once `beta5` is released.